### PR TITLE
RFC: drop f3 dependency and update API

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,11 +1,18 @@
-[target.thumbv7em-none-eabihf]
+[target.thumbv7m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+
 rustflags = [
   "-C", "link-arg=-Tlink.x",
-  "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
-  "-Z", "thinlto=no",
 ]
 
+[target.thumbv7em-none-eabihf]
+runner = 'arm-none-eabi-gdb'
+
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+
 [build]
+#target = "thumbv7m-none-eabi"
 target = "thumbv7em-none-eabihf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,23 @@ repository = "https://github.com/nordmoen/hc-sr04"
 version = "0.1.0"
 
 [dependencies]
-embedded-hal = "0.1.2"
+embedded-hal = "0.2.1"
 nb = "0.1.1"
-stm32f30x-hal = "0.1.2"
 
 [dev-dependencies]
-cortex-m = "0.4.1"
-cortex-m-rtfm = "0.3.1"
+cortex-m = "0.5.7"
+cortex-m-rtfm = { git = "https://github.com/ykomatsu/cortex-m-rtfm", branch = "update" }
+cortex-m-rt = "0.6.4"
+panic-itm = "0.4.0"
 
-[dev-dependencies.cortex-m-rt]
-features = ["abort-on-panic"]
-version = "0.3.13"
-
-[dev-dependencies.f3]
+[target.thumbv7em-none-eabihf.dev-dependencies.f3]
 features = ["rt"]
-version = "0.5.3"
+version = "0.6.1"
 
-[dev-dependencies.stm32f30x-hal]
+[target.thumbv7em-none-eabihf.dev-dependencies.stm32f30x-hal]
 features = ["rt"]
-version = "0.1.2"
+version = "0.2.0"
+
 
 [profile.dev]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,20 @@ name = "hc-sr04"
 readme = "README.md"
 repository = "https://github.com/nordmoen/hc-sr04"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.1"
+embedded-hal = "0.2.2"
 nb = "0.1.1"
 
+[dependencies.void]
+default-features = false
+version = "1.0.2"
+
 [dev-dependencies]
-cortex-m = "0.5.7"
-cortex-m-rtfm = { git = "https://github.com/ykomatsu/cortex-m-rtfm", branch = "update" }
-cortex-m-rt = "0.6.4"
+cortex-m = "0.5.8"
+cortex-m-rtfm = "0.4.0"
+cortex-m-rt = "0.6.7"
 panic-itm = "0.4.0"
 
 [target.thumbv7em-none-eabihf.dev-dependencies.f3]
@@ -30,7 +35,7 @@ version = "0.2.0"
 
 [target.thumbv7m-none-eabi.dev-dependencies.stm32f103xx]
 features = ["rt"]
-version = "0.10.0"
+version = "0.11.0"
 
 [target.thumbv7m-none-eabi.dev-dependencies.stm32f103xx-hal]
 git = "https://github.com/japaric/stm32f103xx-hal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,12 @@ version = "0.6.1"
 features = ["rt"]
 version = "0.2.0"
 
+[target.thumbv7m-none-eabi.dev-dependencies.stm32f103xx]
+features = ["rt"]
+version = "0.10.0"
+
+[target.thumbv7m-none-eabi.dev-dependencies.stm32f103xx-hal]
+git = "https://github.com/japaric/stm32f103xx-hal"
 
 [profile.dev]
 codegen-units = 1

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.core]
-stage = 0
-
-[dependencies.compiler_builtins]
-features = ["mem"]
-stage = 1

--- a/examples/blue-pill.rs
+++ b/examples/blue-pill.rs
@@ -1,0 +1,183 @@
+#![feature(extern_prelude)]
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+extern crate cortex_m;
+
+extern crate cortex_m as cm;
+
+extern crate cortex_m_rtfm as rtfm;
+use rtfm::{app, Resource, Threshold};
+
+extern crate panic_itm;
+
+extern crate stm32f103xx_hal as hal;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::time::Instant;
+use hal::time::MonoTimer;
+use hal::timer::Event;
+use hal::timer::Timer;
+
+extern crate hc_sr04;
+use hc_sr04::{Error, HcSr04};
+
+app! {
+    device: hal::stm32f103xx,
+
+    resources: {
+        static SENSOR: HcSr04<hal::gpio::gpioa::PA1<hal::gpio::Output<hal::gpio::PushPull>>, Delay>;
+        static TIMER: MonoTimer;
+        static EXTI: hal::stm32f103xx::EXTI;
+        static LED: hal::gpio::gpioc::PC13<hal::gpio::Output<hal::gpio::PushPull>>;
+        static ITM: hal::stm32f103xx::ITM;
+        static TMR: hal::timer::Timer<stm32f103xx::TIM3>;
+        static TS: Option<Instant> = None;
+    },
+
+    idle: {
+        resources: [TMR, SENSOR, LED, ITM],
+    },
+
+    tasks: {
+        TIM3: {
+            path: timeout_handler,
+            resources: [TMR, ITM, SENSOR, TS],
+        },
+        EXTI0: {
+            path: echo_handler,
+            resources: [ITM, SENSOR, EXTI, TIMER, TS],
+        }
+    },
+}
+
+fn init(p: init::Peripherals, _r: init::Resources) -> init::LateResources {
+    // configure clocks
+    let mut flash = p.device.FLASH.constrain();
+    let mut rcc = p.device.RCC.constrain();
+    let clocks = rcc
+        .cfgr
+        .sysclk(8.mhz())
+        .pclk1(8.mhz())
+        .freeze(&mut flash.acr);
+
+    let mut gpioa = p.device.GPIOA.split(&mut rcc.apb2);
+    let mut gpioc = p.device.GPIOC.split(&mut rcc.apb2);
+
+    let delay = Delay::new(p.core.SYST, clocks);
+    let monotimer = MonoTimer::new(p.core.DWT, clocks);
+
+    // configure PC13 pin to blink LED
+    let led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+
+    // configure PA0 pin to capture echo
+    gpioa.pa0.into_floating_input(&mut gpioa.crl);
+
+    // configure PA1 pin to trigger pulse
+    let trig = gpioa.pa1.into_push_pull_output(&mut gpioa.crl);
+
+    // configure and start TIM3 periodic timer
+    let tmr = Timer::tim3(p.device.TIM3, 1.hz(), clocks, &mut rcc.apb1);
+
+    // setup EXTI0 interrupt: pin PA0
+    p.device.EXTI.imr.write(|w| w.mr0().set_bit());
+    p.device.EXTI.ftsr.write(|w| w.tr0().set_bit());
+    p.device.EXTI.rtsr.write(|w| w.tr0().set_bit());
+
+    // create sensor
+    let sensor = HcSr04::new(trig, delay, monotimer.frequency().0);
+
+    // init late resources
+    init::LateResources {
+        SENSOR: sensor,
+        LED: led,
+        EXTI: p.device.EXTI,
+        TIMER: monotimer,
+        TMR: tmr,
+        ITM: p.core.ITM,
+    }
+}
+
+fn idle(t: &mut Threshold, mut r: idle::Resources) -> ! {
+    loop {
+        r.TMR.claim_mut(t, |s, _t| {
+            s.start(1.hz());
+            s.listen(Event::Update);
+        });
+
+        loop {
+            let dist = r.SENSOR.claim_mut(t, |s, _t| s.distance());
+            match dist {
+                Ok(dist) => {
+                    r.TMR.claim_mut(t, |s, _t| {
+                        s.unlisten(Event::Update);
+                    });
+
+                    match dist {
+                        Some(dist) => {
+                            let cm = dist.cm();
+                            r.ITM.claim_mut(t, |s, _t| {
+                                iprintln!(&mut s.stim[0], "{:?}", cm);
+                            });
+                            break;
+                        }
+                        None => {
+                            r.ITM.claim_mut(t, |s, _t| {
+                                iprintln!(&mut s.stim[0], "Err");
+                            });
+                            break;
+                        }
+                    }
+                }
+                Err(Error::WouldBlock) => {
+                    rtfm::wfi();
+                }
+                Err(_) => unreachable!(),
+            }
+        }
+
+        for _ in 0..10000 {
+            cm::asm::nop();
+        }
+    }
+}
+
+fn echo_handler(_t: &mut Threshold, mut r: EXTI0::Resources) {
+    let dbg = &mut r.ITM.stim[0];
+
+    match *r.TS {
+        Some(ts) => {
+            let delta = ts.elapsed();
+            *r.TS = None;
+            iprintln!(dbg, "stop capture: {:?}", delta);
+
+            r.SENSOR
+                .capture(delta)
+                .expect("echo handler: sensor in wrong state!");
+        }
+        None => {
+            *r.TS = Some(r.TIMER.now());
+            iprintln!(dbg, "start capture");
+
+            r.SENSOR
+                .capture(0)
+                .expect("echo handler: sensor in wrong state!");
+        }
+    }
+
+    r.EXTI.pr.write(|w| w.pr0().set_bit());
+}
+
+fn timeout_handler(_t: &mut Threshold, mut r: TIM3::Resources) {
+    let dbg = &mut r.ITM.stim[0];
+
+    iprintln!(dbg, "timeout");
+    r.SENSOR
+        .timedout()
+        .expect("timeout handler: sensor in wrong state!");
+    r.TMR.unlisten(Event::Update);
+    *r.TS = None;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,10 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(never_type)]
 #![no_std]
+
+extern crate void;
+use void::Void;
 
 extern crate embedded_hal as hal;
 use hal::blocking::delay::DelayUs;
@@ -118,7 +120,7 @@ where
     /// This method will not return another error except [`WouldBlock`][1].
     ///
     /// [1]: https://docs.rs/nb/0.1.1/nb/enum.Error.html
-    pub fn distance(&mut self) -> nb::Result<Option<Distance>, !> {
+    pub fn distance(&mut self) -> nb::Result<Option<Distance>, Void> {
         match self.mode {
             // Start a new sensor measurement
             Mode::Idle => {


### PR DESCRIPTION
Hi,

Here is an RFC patch set that attempts to get rid of explicit f3 dependency and make API more simple and generic. The selected approach moves time tracking to application. The idea behind this approach is as follows:
* MonoTimer is not a part of embedded HAL. Embedded HAL contains only Countdown and Periodic timers which are not suitable for this particular task.
* IIUC it makes sense to keep MonoTimer ownership in application so that measurements can be used by other drivers as well.

For more details see commit messages.

Tested on blue-pill board using stm32f103xx-hal crate.

Regards,
Sergey